### PR TITLE
Patches to make the custom vm provider work.

### DIFF
--- a/falk/vm/__init__.py
+++ b/falk/vm/__init__.py
@@ -61,21 +61,19 @@ class ContainerConfig:
             if value:
                 # ssh key loading:
                 if key == "ssh_known_host_key":
-                    # it's either the key directly or a file
-                    if value.startswith("ssh-"):
-                        # it's directly stored
-                        self.ssh_known_host_key = value
-                    else:
-                        # it's given as path to public key storage file
-                        path = Path(os.path.expanduser(value))
-
+                    # either the key is a file, or a line from the known hosts file.
+                    path = Path(os.path.expanduser(value))
+                    print(path)
+                    if path.is_file():
                         # determine location relative to the falk.conf
                         if not path.is_absolute():
                             path = cfgpath / path
 
                         with open(str(path)) as keyfile:
                             self.ssh_known_host_key = keyfile.read().strip()
-
+                    else:
+                        # it's directly stored
+                        self.ssh_known_host_key = value
                 # simply copy the value from the config:
                 else:
                     setattr(self, key, value)
@@ -207,4 +205,4 @@ class Container(metaclass=ContainerMeta):
 
 
 # force class definitions too fill CONTAINERS dict
-from . import qemu, xen, docker, lxc, clearlinux, nspawn, rkt
+from . import qemu, xen, docker, lxc, clearlinux, nspawn, rkt, custom

--- a/falk/vm/custom.py
+++ b/falk/vm/custom.py
@@ -29,7 +29,7 @@ class Custom(Container):
 
         return cfg
 
-    def prepare(self, manage=False):
+    async def prepare(self, manage=False):
         self.manage = manage
 
         command = shlex.split(self.cfg.prepare)
@@ -39,8 +39,8 @@ class Custom(Container):
         if subprocess.call(command) != 0:
             raise RuntimeError("could not prepare container")
 
-    def launch(self):
-        command = shlex.split(self.cfg.launch) + [self.ssh_port]
+    async def launch(self):
+        command = shlex.split(self.cfg.launch)# + [self.ssh_port]
 
         self.process = subprocess.Popen(
             command, stdin=subprocess.PIPE,
@@ -50,7 +50,7 @@ class Custom(Container):
 
         self.process.stdin.close()
 
-    def is_running(self):
+    async def is_running(self):
         if self.process:
             running = self.process.poll() is None
         else:
@@ -58,15 +58,18 @@ class Custom(Container):
 
         return running
 
-    def terminate(self):
+    async def terminate(self):
         if self.process:
             self.process.kill()
             self.process.wait()
 
-    def cleanup(self):
+    async def cleanup(self):
         command = shlex.split(self.cfg.cleanup)
         if self.manage:
             command.append("--manage")
 
         if subprocess.call(command) != 0:
             raise RuntimeError("could not clean up container")
+
+    async def wait_for_shutdown(self, timeout):
+        return False


### PR DESCRIPTION
Usage:

In your `falk.conf` file, set the type of virtual machine to be custom, and enter commands to make your vm work. For example:

``` ini
# in falk.conf

[someVirtualMachineTag]
# name = macOS
type = custom

# ssh_user = chantal
# ssh_known_host_key =
# ssh_host = chantal.local

prepare = echo Simulating VM Prepare
launch = echo Simulating VM Launch
cleanup = echo Simulating VM Cleanup
```