### PR TITLE
Make chantal clone only needed branch

### DIFF
--- a/chantal/build.py
+++ b/chantal/build.py
@@ -46,13 +46,21 @@ def build_job(args):
         else:
             shallow = ""
 
-        run_command("git clone " + shallow +
-                    shlex.quote(args.clone_location) +
-                    " " + args.work_location, base_env)
+        if args.treeish:
+            run_command("git init " + args.work_location, base_env)
+        else:
+            run_command("git clone " + shallow +
+                        shlex.quote(args.clone_location) +
+                        " " + args.work_location, base_env)
 
     os.chdir(args.work_location)
 
     if args.treeish:
+        run_command("git remote add origin " +
+                    shlex.quote(args.clone_location), base_env)
+        run_command("git fetch " + shallow + "--prune " +
+                    "origin " + args.treeish + ":" + args.treeish,
+                    base_env)
         run_command("git checkout -q " + args.treeish, base_env)
 
     try:

--- a/chantal/build.py
+++ b/chantal/build.py
@@ -48,20 +48,18 @@ def build_job(args):
 
         if args.treeish:
             run_command("git init " + args.work_location, base_env)
+            os.chdir(args.work_location)
+            run_command("git remote add origin " +
+                    shlex.quote(args.clone_location), base_env)
+            run_command("git fetch " + shallow + "--prune " +
+                        "origin " + args.treeish + ":" + args.treeish,
+                        base_env)
+            run_command("git checkout -q " + args.treeish, base_env)
         else:
             run_command("git clone " + shallow +
                         shlex.quote(args.clone_location) +
                         " " + args.work_location, base_env)
-
-    os.chdir(args.work_location)
-
-    if args.treeish:
-        run_command("git remote add origin " +
-                    shlex.quote(args.clone_location), base_env)
-        run_command("git fetch " + shallow + "--prune " +
-                    "origin " + args.treeish + ":" + args.treeish,
-                    base_env)
-        run_command("git checkout -q " + args.treeish, base_env)
+            os.chdir(args.work_location)
 
     try:
         with open(args.filename) as controlfile:

--- a/etc/project.conf.example
+++ b/etc/project.conf.example
@@ -16,6 +16,8 @@ job_max_output = 100MiB
 # name of the build job task configuration file within the repo
 job_desc_file = kevinfile
 
+# git configuration
+git_fetch_depth = 0
 
 [github_webhook]
 # github delivers an authenticated captain hook to kevin

--- a/kevin/chantal.py
+++ b/kevin/chantal.py
@@ -18,10 +18,11 @@ class Chantal(AsyncWith):
 
     # TODO: different connection methods (e.g. agent, non-ssh commands)
     """
-    def __init__(self, machine, loop=None):
+    def __init__(self, machine, git_config, loop=None):
         self.machine = machine
         self.loop = loop or asyncio.get_event_loop()
         self.ssh_worked = self.loop.create_future()
+        self.git_config = git_config
 
     def can_connect(self):
         """ return if the vm ssh connection was successful once. """
@@ -193,6 +194,7 @@ class Chantal(AsyncWith):
             ("python3", "-u", "-m", "chantal",
              "--clone", job.build.clone_url,
              "--checkout", job.build.commit_hash,
+             "--clone-depth", self.git_config["shallow"],
              "--desc-file", job.build.project.cfg.job_desc_file,
              job.name),
             timeout=job.build.project.cfg.job_timeout,

--- a/kevin/job.py
+++ b/kevin/job.py
@@ -122,6 +122,10 @@ class Job(Watcher, Watchable):
         # are all updates from the job in the update list already?
         self.all_loaded = False
 
+        self.git_config = {
+            "shallow": self.project.cfg.git_fetch_depth,
+        }
+
         # check if the job was completed.
         # this means we can do a reconstruction.
         if not CFG.args.volatile:
@@ -325,7 +329,7 @@ class Job(Watcher, Watchable):
             # machine was acquired, now boot it.
             await self.set_state("waiting", "booting machine")
 
-            async with Chantal(machine) as chantal:
+            async with Chantal(machine, self.git_config) as chantal:
 
                 # wait for the machine to be reachable
                 await chantal.wait_for_connection(timeout=60, try_timeout=20)

--- a/kevin/project_config.py
+++ b/kevin/project_config.py
@@ -44,6 +44,7 @@ class Config:
             self.job_silence_timeout = parse_time(
                 projcfg["job_silence_timeout"])
             self.job_desc_file = projcfg["job_desc_file"]
+            self.git_fetch_depth = projcfg["git_fetch_depth"]
 
             # configuration for triggers and actions
             # these define what can trigger a project job,


### PR DESCRIPTION
changed the default --depth from 0 to 5, so that way chantal will only clone one branch implicitly with the specified number of commits