### PR TITLE
Fixing some simulator running issues

### DIFF
--- a/doc/simulator.md
+++ b/doc/simulator.md
@@ -5,7 +5,8 @@ Hosting site simulator
 To allow development without a test repo e.g. at github,
 we provide a simulator that mimics the api of that service.
 
-These are located in `kevin/simulator`.
+These are located in `kevin/simulator`. And for run the simulator,
+you will need to uncomment the `dyn_host` in the `kevin.conf`.
 
 
 Example for building `some-repo` with a kevin currently running with

--- a/etc/kevin.conf.example
+++ b/etc/kevin.conf.example
@@ -19,6 +19,7 @@ mandy_url = http://your.kevin.host/mandy/
 
 # kevin's web worker will listen on that port
 dyn_port = 7777
+# dyn_host = 0.0.0.0
 
 # set those to the host/port where mandy can reach kevin
 # if kevin is behind a proxy, set the values to reach that proxy

--- a/kevin/simulator/github.py
+++ b/kevin/simulator/github.py
@@ -158,6 +158,11 @@ class GitHub(service.Service):
                 },
                 "html_url": repo,
                 "statuses_url": status_url,
+                "issue_url": repo+"/issues/1",
+                "labels": {
+                    "name": "mylabel",
+                    "value": "my awesome label"
+                },
             },
             "repository": {
                 "full_name": reponame,

--- a/kevin/simulator/util.py
+++ b/kevin/simulator/util.py
@@ -14,7 +14,7 @@ async def get_hash(repo):
     """
 
     proc = await asyncio.create_subprocess_exec(
-        "git", "ls-remote", repo,
+        "git", "ls-remote", repo, "HEAD",
         stdout=asyncio.subprocess.PIPE
     )
 


### PR DESCRIPTION
Fixed the problem to determine the HEAD hash when the repo have too many hashes. Inserted the required payload fields that are missing on the simulator, also documented the use necessity of the `dyn_host`.